### PR TITLE
Feature/minor test changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ We would like you to write an application that provides a RESTful API onto third
 
 We have provided a core skeleton for a Java Spring Boot application. You are asked to use an external API that provides facts about cats. Documentation on the API can be found at: https://catfact.ninja/ and the main APIs that you will use will be one or both of https://catfact.ninja/facts and https://catfact.ninja/breeds
 
-An initial endpoint has been defined at `/facts` which will return a listing of all cat facts available in the target API service using a `FactDTO`.
+Initial endpoints have been defined at `/facts` and `/breeds` which will return a listing of all cat facts or all cat breeds respectively.
 
 We would like you to add to this application with the following requirements:
 
 **Basic Requirements**
 
 * Expose suitably designed and implemented endpoints to retrieve the data from the `Cat Facts API Service`
-* Return `fact`s filtered by a provided `keyword` parameter, for example `Egypt`
-* Return all breeds available from the source API as a list of `breed`s
+* Amend the `/facts` endpoint to return `fact`s filtered by an optional `q` parameter, for example `?q=Egypt`
+* Add a feature that allows a user to limit the number of `breed`s that are returned from the `/breeds` endpoint based on an optional parameter
 * Show a data summary response showing the count of all breeds of cats grouped by their `coat` properties
 
 **Stretch Goals**

--- a/src/main/java/uk/co/asto/interview/cats/controller/BreedController.java
+++ b/src/main/java/uk/co/asto/interview/cats/controller/BreedController.java
@@ -1,0 +1,46 @@
+package uk.co.asto.interview.cats.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+import uk.co.asto.interview.cats.model.BreedDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "/breeds")
+public class BreedController {
+    private static final Logger LOG = LoggerFactory.getLogger(BreedController.class.getSimpleName());
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public BreedController(final RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @GetMapping(path = "")
+    public ResponseEntity<List<BreedDTO>> getCatBreeds() {
+        ResponseEntity<Map> response = restTemplate.getForEntity("/breeds", Map.class);
+
+        List<BreedDTO> breeds = new ArrayList<BreedDTO>();
+
+        for (Map entry : (List<Map>) response.getBody().get("data")) {
+            breeds.add(new BreedDTO(
+                    (String) entry.get("breed"),
+                    (String) entry.get("country"),
+                    (String) entry.get("origin"),
+                    (String) entry.get("coat"),
+                    (String) entry.get("pattern")));
+        }
+
+        return ResponseEntity.ok().body(breeds);
+    }
+}

--- a/src/main/java/uk/co/asto/interview/cats/model/BreedDTO.java
+++ b/src/main/java/uk/co/asto/interview/cats/model/BreedDTO.java
@@ -1,0 +1,46 @@
+package uk.co.asto.interview.cats.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BreedDTO {
+    private final String breed;
+    private final String country;
+    private final String origin;
+    private final String coat;
+    private final String pattern;
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public BreedDTO(
+            @JsonProperty("breed") final String breed,
+            @JsonProperty("country") final String country,
+            @JsonProperty("origin") final String origin,
+            @JsonProperty("coat") final String coat,
+            @JsonProperty("pattern") final String pattern) {
+        this.breed = breed;
+        this.country = country;
+        this.origin = origin;
+        this.coat = coat;
+        this.pattern = pattern;
+    }
+
+    public String getBreed() {
+        return breed;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public String getCoat() {
+        return coat;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+}

--- a/src/main/java/uk/co/asto/interview/cats/model/FactDTO.java
+++ b/src/main/java/uk/co/asto/interview/cats/model/FactDTO.java
@@ -1,12 +1,14 @@
 package uk.co.asto.interview.cats.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FactDTO {
     @JsonProperty(value = "fact")
     private final String fact;
 
-    public FactDTO(final String fact) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public FactDTO(@JsonProperty("fact") final String fact) {
         this.fact = fact;
     }
 

--- a/src/test/java/uk/co/asto/interview/cats/controller/BreedControllerTest.java
+++ b/src/test/java/uk/co/asto/interview/cats/controller/BreedControllerTest.java
@@ -1,0 +1,39 @@
+package uk.co.asto.interview.cats.controller;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.asto.interview.cats.CatFactApiApplication;
+import uk.co.asto.interview.cats.model.BreedDTO;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        classes = { CatFactApiApplication.class },
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class BreedControllerTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    public void shouldReturnHttp200OnSuccess() throws Exception {
+        ResponseEntity<List<BreedDTO>> response = this.restTemplate.exchange(
+                "/breeds",
+                HttpMethod.GET,
+                null,
+                new ParameterizedTypeReference<List<BreedDTO>>() {});
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/src/test/java/uk/co/asto/interview/cats/controller/FactControllerTest.java
+++ b/src/test/java/uk/co/asto/interview/cats/controller/FactControllerTest.java
@@ -9,7 +9,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)


### PR DESCRIPTION
Added a basic implementation for the `/breeds` endpoint. Included basic tests for either mocked endpoint tests or integration tests. Updated `README` to amend the requirements slightly to the following:
* Add a query parameter to filter the `fact`s based on content.
* Add a query parameter to limit the number of `breed`s
* Add an endpoint to return a summary of breeds.