### PR TITLE
Bug Fix/ Minor Refactor

### DIFF
--- a/src/main/java/uk/co/asto/interview/cats/controller/BreedController.java
+++ b/src/main/java/uk/co/asto/interview/cats/controller/BreedController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
-import uk.co.asto.interview.cats.model.BreedDTO;
+import uk.co.asto.interview.cats.model.Breed;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,13 +27,13 @@ public class BreedController {
     }
 
     @GetMapping
-    public ResponseEntity<List<BreedDTO>> getCatBreeds() {
+    public ResponseEntity<List<Breed>> getCatBreeds() {
         final ResponseEntity<Map> response = restTemplate.getForEntity("/breeds", Map.class);
 
-        final List<BreedDTO> breeds = new ArrayList<>();
+        final List<Breed> breeds = new ArrayList<>();
 
         for (Map entry : (List<Map>) response.getBody().get("data")) {
-            breeds.add(new BreedDTO(
+            breeds.add(new Breed(
                     (String) entry.get("breed"),
                     (String) entry.get("country"),
                     (String) entry.get("origin"),

--- a/src/main/java/uk/co/asto/interview/cats/controller/FactController.java
+++ b/src/main/java/uk/co/asto/interview/cats/controller/FactController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
-import uk.co.asto.interview.cats.model.FactDTO;
+import uk.co.asto.interview.cats.model.Fact;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,13 +27,13 @@ public class FactController {
     }
 
     @GetMapping
-    public ResponseEntity<List<FactDTO>> getCatFacts() {
+    public ResponseEntity<List<Fact>> getCatFacts() {
         final ResponseEntity<Map> response = restTemplate.getForEntity("/facts?limit=1000", Map.class);
 
-        final List<FactDTO> facts = new ArrayList<>();
+        final List<Fact> facts = new ArrayList<>();
 
         for (Map entry : (List<Map>) response.getBody().get("data")) {
-            facts.add(new FactDTO((String) entry.get("fact")));
+            facts.add(new Fact((String) entry.get("fact")));
         }
 
         return ResponseEntity.ok().body(facts);

--- a/src/main/java/uk/co/asto/interview/cats/model/Breed.java
+++ b/src/main/java/uk/co/asto/interview/cats/model/Breed.java
@@ -3,7 +3,7 @@ package uk.co.asto.interview.cats.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class BreedDTO {
+public class Breed {
     private final String breed;
     private final String country;
     private final String origin;
@@ -11,7 +11,7 @@ public class BreedDTO {
     private final String pattern;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public BreedDTO(
+    public Breed(
             @JsonProperty("breed") final String breed,
             @JsonProperty("country") final String country,
             @JsonProperty("origin") final String origin,

--- a/src/main/java/uk/co/asto/interview/cats/model/Fact.java
+++ b/src/main/java/uk/co/asto/interview/cats/model/Fact.java
@@ -3,12 +3,12 @@ package uk.co.asto.interview.cats.model;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class FactDTO {
+public class Fact {
     @JsonProperty(value = "fact")
     private final String fact;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public FactDTO(@JsonProperty("fact") final String fact) {
+    public Fact(@JsonProperty("fact") final String fact) {
         this.fact = fact;
     }
 

--- a/src/test/java/uk/co/asto/interview/cats/controller/BreedControllerTest.java
+++ b/src/test/java/uk/co/asto/interview/cats/controller/BreedControllerTest.java
@@ -10,8 +10,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.co.asto.interview.cats.model.BreedDTO;
-import uk.co.asto.interview.cats.model.FactDTO;
+import uk.co.asto.interview.cats.model.Breed;
 
 import java.util.List;
 
@@ -28,7 +27,7 @@ public class BreedControllerTest {
     class BreedsEndpoint {
         @Test
         public void shouldReturnHttp200OnSuccess() throws Exception {
-            final ResponseEntity<List<BreedDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Breed>> response = restTemplate.exchange(
                     "/breeds",
                     HttpMethod.GET,
                     null,
@@ -41,7 +40,7 @@ public class BreedControllerTest {
         public void shouldReturnAllBreedsUnfiltered() {
             final Integer expectedNumberOfBreeds = 25;
 
-            final ResponseEntity<List<BreedDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Breed>> response = restTemplate.exchange(
                     "/breeds",
                     HttpMethod.GET,
                     null,
@@ -58,7 +57,7 @@ public class BreedControllerTest {
         public void shouldReturnSpecifiedBreedsWithLimitParam() throws Exception {
             final Integer numberToFetch = 10;
 
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Breed>> response = restTemplate.exchange(
                     String.format("/breeds?limit=%d", numberToFetch),
                     HttpMethod.GET,
                     null,
@@ -71,7 +70,7 @@ public class BreedControllerTest {
         public void shouldReturnEmptyListIfLimitIsZero() {
             final Integer numberToFetch = 0;
 
-            final ResponseEntity<List<BreedDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Breed>> response = restTemplate.exchange(
                     String.format("/breeds?limit=%d", numberToFetch),
                     HttpMethod.GET,
                     null,

--- a/src/test/java/uk/co/asto/interview/cats/controller/FactControllerTest.java
+++ b/src/test/java/uk/co/asto/interview/cats/controller/FactControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.co.asto.interview.cats.model.FactDTO;
+import uk.co.asto.interview.cats.model.Fact;
 
 import java.util.List;
 
@@ -28,7 +28,7 @@ public class FactControllerTest {
     class FactsEndpoint {
         @Test
         public void shouldReturnHttp200OnSuccess() throws Exception {
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Fact>> response = restTemplate.exchange(
                     "/facts",
                     HttpMethod.GET,
                     null,
@@ -42,7 +42,7 @@ public class FactControllerTest {
         public void shouldReturnAllFactsUnfiltered() throws Exception {
             final Integer unfilteredFactsCount = 332;
 
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Fact>> response = restTemplate.exchange(
                     "/facts",
                     HttpMethod.GET,
                     null,
@@ -60,7 +60,7 @@ public class FactControllerTest {
             final Integer filteredFactsCount = 11;
             final String queryParameter = "Egypt";
 
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Fact>> response = restTemplate.exchange(
                     String.format("/facts?q=%s", queryParameter),
                     HttpMethod.GET,
                     null,
@@ -73,7 +73,7 @@ public class FactControllerTest {
         public void shouldReturnEmptyListIfSearchTermDoesNotMatch() {
             final String nonExistentTerm = "DogsAreBetter";
 
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Fact>> response = restTemplate.exchange(
                     String.format("/facts?q=%s", nonExistentTerm),
                     HttpMethod.GET,
                     null,
@@ -87,7 +87,7 @@ public class FactControllerTest {
             final String searchTerm = "Egypt";
             final SoftAssertions softly = new SoftAssertions();
 
-            final ResponseEntity<List<FactDTO>> response = restTemplate.exchange(
+            final ResponseEntity<List<Fact>> response = restTemplate.exchange(
                     String.format("/facts?q=%s", searchTerm),
                     HttpMethod.GET,
                     null,


### PR DESCRIPTION
**What does it solve?**
One of the tests was returning the wrong type so wouldn't have been expected to pass (copy/paste issue from a previous incarnation). The `FactDTO` and `BreedDTO` are a bit of a mouthful and it is easier to refer to them as a more general entity rather than having their expected purpose built in to the name.
**How does it solve it?**
Renames the `xxxDTO` classes to not have the `DTO` part. Resolves the broken test by correcting the callout return type.